### PR TITLE
(feature) add track method from native LD client

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNLaunchDarklyModule.java
+++ b/android/src/main/java/com/reactlibrary/RNLaunchDarklyModule.java
@@ -13,15 +13,16 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import com.launchdarkly.android.FeatureFlagChangeListener;
 import com.launchdarkly.android.LDClient;
 import com.launchdarkly.android.LDConfig;
 import com.launchdarkly.android.LDUser;
 import com.launchdarkly.android.LaunchDarklyException;
 
-import java.util.Collections;
 import java.util.concurrent.Future;
-import java.util.concurrent.ExecutionException;
 
 public class RNLaunchDarklyModule extends ReactContextBaseJavaModule {
 
@@ -136,9 +137,15 @@ public class RNLaunchDarklyModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void track(String goalName) {
+  public void track(String goalName, ReadableMap data) {
     if (ldClient != null) {
-      ldClient.track(goalName);
+      Gson json = new GsonBuilder().create();
+      try {
+        JsonObject result = json.toJsonTree(data.toHashMap()).getAsJsonObject();
+        ldClient.track(goalName, result);
+      } catch (Exception e) {
+        Log.d("RNLaunchDarklyModule", e.getMessage());
+      }
     }
   }
 }

--- a/android/src/main/java/com/reactlibrary/RNLaunchDarklyModule.java
+++ b/android/src/main/java/com/reactlibrary/RNLaunchDarklyModule.java
@@ -134,4 +134,11 @@ public class RNLaunchDarklyModule extends ReactContextBaseJavaModule {
     String variationResult = ldClient != null ? ldClient.stringVariation(flagName, fallback) : fallback;
     callback.invoke(variationResult);
   }
+
+  @ReactMethod
+  public void track(String goalName) {
+    if (ldClient != null) {
+      ldClient.track(goalName);
+    }
+  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,3 +11,4 @@ export function boolVariation(flagName: string, fallback: boolean, callback: (st
 export function stringVariation(flagName: string, fallback: string, callback: (status: string) => void): string;
 export function addFeatureFlagChangeListener(flagName: string, callback: (flagName: string) => void): void;
 export function unsubscribe(): void;
+export function track(goalName: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,4 +11,4 @@ export function boolVariation(flagName: string, fallback: boolean, callback: (st
 export function stringVariation(flagName: string, fallback: string, callback: (status: string) => void): string;
 export function addFeatureFlagChangeListener(flagName: string, callback: (flagName: string) => void): void;
 export function unsubscribe(): void;
-export function track(goalName: string): void;
+export function track(goalName: string, data: any): void;

--- a/index.js
+++ b/index.js
@@ -24,6 +24,10 @@ class LaunchDarkly {
     RNLaunchDarkly.stringVariation(featureName, fallback, callback);
   }
 
+  track (goalName) {
+    RNLaunchDarkly.track(goalName);
+  }
+
   addFeatureFlagChangeListener (featureName, callback) {
     if (Platform.OS === 'android') {
       RNLaunchDarkly.addFeatureFlagChangeListener(featureName);

--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ class LaunchDarkly {
     RNLaunchDarkly.stringVariation(featureName, fallback, callback);
   }
 
-  track (goalName) {
-    RNLaunchDarkly.track(goalName);
+  track (goalName, data) {
+    RNLaunchDarkly.track(goalName, data);
   }
 
   addFeatureFlagChangeListener (featureName, callback) {

--- a/ios/RNLaunchDarkly.m
+++ b/ios/RNLaunchDarkly.m
@@ -80,9 +80,9 @@ RCT_EXPORT_METHOD(stringVariation:(NSString*)flagName fallback:(NSString*)fallba
     callback(@[flagValue]);
 }
 
-RCT_EXPORT_METHOD(track:(NSString*)goalName)
+RCT_EXPORT_METHOD(track:(NSString*)goalName data:(NSDictionary *)data)
 {
-    [[LDClient sharedInstance] track:goalName];
+    [[LDClient sharedInstance] track:goalName data:data];
 }
 
 - (void)handleFeatureFlagChange:(NSNotification *)notification

--- a/ios/RNLaunchDarkly.m
+++ b/ios/RNLaunchDarkly.m
@@ -80,6 +80,11 @@ RCT_EXPORT_METHOD(stringVariation:(NSString*)flagName fallback:(NSString*)fallba
     callback(@[flagValue]);
 }
 
+RCT_EXPORT_METHOD(track:(NSString*)goalName)
+{
+    [[LDClient sharedInstance] track:goalName];
+}
+
 - (void)handleFeatureFlagChange:(NSNotification *)notification
 {
     NSString *flagName = notification.userInfo[@"flagkey"];


### PR DESCRIPTION
## Link to story (or tech task)

https://app.clubhouse.io/hellohippo/story/15227/aadev-i-need-reactnative-implementation-for-ld-track-sdk-method

## Description

Added track method from native LD client for IOS and Android

https://docs.launchdarkly.com/docs/ios-sdk-reference#section-track
https://docs.launchdarkly.com/docs/android-sdk-reference#section-track

## Demo (screenshots or video)

At this demo I use track method from react-native-launch-darkly to send goal called `check-ab`.

IOS

https://monosnap.com/file/YWfOni0jBpzSaWOev4juJAIM94Yndi

Android

https://monosnap.com/file/PNTJwlbbk0qJe1nPqcJhfZeOAk6Avp